### PR TITLE
Fix formatting issue with large unicode characters

### DIFF
--- a/src/templates/courses_x_assignments_x.html
+++ b/src/templates/courses_x_assignments_x.html
@@ -92,6 +92,12 @@ Due Date: {{ formatted_due_date|e }}{% endif %}</pre>
 {% endif %}
 
 {% if takes_course or instructs_course %}
+<style type="text/css">
+.table td:first-child {
+  overflow-x: auto;
+  max-width: 25em;
+}
+</style>
 <h3>Scores:</h3>
 <table class="table table-stripped">
   <thead>


### PR DESCRIPTION
CSS addition to set `max-width` of first column to `25em` and `overflow-x` to `auto` to prevent abuse of `﷽` and similar characters in display name.

<div align="center"><br><br>
<img src="https://media0.giphy.com/media/5Ztn33chuvutW/giphy.gif" width="200">
</div>