### PR TITLE
set overflow-x to auto for score field

### DIFF
--- a/src/templates/courses_x_assignments_x.html
+++ b/src/templates/courses_x_assignments_x.html
@@ -95,7 +95,7 @@ Due Date: {{ formatted_due_date|e }}{% endif %}</pre>
 
 {% if takes_course or instructs_course %}
 <style type="text/css">
-.table td:first-child {
+.table td:first-child, .table td:nth-child(2) {
   overflow-x: auto;
   max-width: 25em;
 }


### PR DESCRIPTION
If the score is too big (e.g. 10^100), it begins to overflow and break formatting. This fix keeps that from happening.